### PR TITLE
Create ros2-build-check-bot.yml

### DIFF
--- a/.github/workflows/ros2-build-check-bot.yml
+++ b/.github/workflows/ros2-build-check-bot.yml
@@ -1,0 +1,24 @@
+name: ROS2-humble Build Check
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.head_ref }}
+    - name: Setup ROS2
+      uses: ros-tooling/setup-ros@v0.6
+      with:
+        required-ros-distributions: humble
+    - name: Build
+      uses: ros-tooling/action-ros-ci@v0.3
+      with:
+        package-name: icm_20948 serial
+        target-ros2-distro: humble
+        vcs-repo-file-url: "${{ github.workspace }}/icm_20948.rosinstall"
+        skip-tests: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ICM_20948 v2.0 [![](https://img.shields.io/badge/ROS2-humble-important?style=flat-square&logo=ros)](https://github.com/Alpaca-zip/icm_20948/tree/humble-devel) [![](https://img.shields.io/badge/ROS-noetic-blue?style=flat-square&logo=ros)](https://github.com/Alpaca-zip/icm_20948/tree/noetic-devel)
+# ICM_20948 v2.0 [![ROS2-humble Build Check](https://github.com/Alpaca-zip/icm_20948/actions/workflows/ros2-build-check-bot.yml/badge.svg?event=pull_request)](https://github.com/Alpaca-zip/icm_20948/actions/workflows/ros2-build-check-bot.yml)
 
 ROS2 package for the ICM-20948 with Seeeduino XIAO.  
 Older version: [old-devel](https://github.com/Alpaca-zip/icm_20948/tree/old-devel)


### PR DESCRIPTION
- This pull request will add a GitHub Actions workflow that will automatically build a project for ROS2 Humble on Ubuntu 22.04.
- ROS2 installation dependencies are defined in the `icm_20948.rosinstall` and `package.xml` files in the repository root.
